### PR TITLE
Improve LCSC field detection

### DIFF
--- a/jlc_lib/generate_bom.py
+++ b/jlc_lib/generate_bom.py
@@ -20,7 +20,7 @@ from jlc_lib import kicad_netlist_reader
 import csv
 import re
 
-LCSC_PART_NUMBER_MATCHER=re.compile('^C[0-9]+')
+LCSC_PART_NUMBER_MATCHER=re.compile('^C[0-9]+$')
 
 def GenerateBOM(input_filename, output_filename):
   net = kicad_netlist_reader.netlist(input_filename)


### PR DESCRIPTION
Some MPNs may look similar to a LCSC part number so the detection
was failing in certain cases.

For example, it was picking up C0603C270J5GAC (MPN) instead of
C1656 (LCSC part number).

This new re doesn't allow anything other that numbers after the C,
Cxxxx, which should discard cases like this, and should still work
for every LCSC part number as far as I'm aware.

Thanks!