### PR TITLE
Add electrolytic capacitor rotation

### DIFF
--- a/jlc_kicad_tools/cpl_rotations_db.csv
+++ b/jlc_kicad_tools/cpl_rotations_db.csv
@@ -18,3 +18,4 @@
 "^CP_Tantalum_Case-A_EIA-3216-18",180
 "^CP_Elec_8x10.5",180
 "^CP_Elec_6.3x7.7",180
+"^CP_Elec_8x6.7",180


### PR DESCRIPTION
Hi,

this change adds the correct rotation for CP_Elec_8x6.7 electrolytic and solid polymer capacitors. 
I have validated the correct orientation using the preview on JLCs website.

Thanks! 