### PR TITLE
Remove diode rotation fixes

### DIFF
--- a/jlc_kicad_tools/cpl_rotations_db.csv
+++ b/jlc_kicad_tools/cpl_rotations_db.csv
@@ -11,9 +11,6 @@
 "^SOIC-",270
 "^SOP-18_",0
 "^VSSOP-10_",270
-"^D_SOD-123",180
-"^D_SMA",180
-"^D_SMB",180
 "^CP_Tantalum_Case-A_EIA-3216-18",180
 "^CP_Elec_8x10.5",180
 "^CP_Elec_6.3x7.7",180


### PR DESCRIPTION
JLC changed the handling of diodes regarding their orientation. They either changed the default rotation by 180° or reversed the meaning of `+` and `-`.

This is how a PCB looks with my changes applied:
![LJC_diode_rotation](https://user-images.githubusercontent.com/2042858/81474552-92e28800-9206-11ea-9b6d-13b183d4eee2.png)

I've confirmed with JLC that + designates the anode while - is the cathode. This is the E-Mail they sent me in response:
![JLC_email](https://user-images.githubusercontent.com/2042858/81474551-91b15b00-9206-11ea-88e5-59516200ce53.png)

