### PR TITLE
Updated tantalum cap footprint name

### DIFF
--- a/jlc_kicad_tools/cpl_rotations_db.csv
+++ b/jlc_kicad_tools/cpl_rotations_db.csv
@@ -11,7 +11,7 @@
 "^SOIC-",270
 "^SOP-18_",0
 "^VSSOP-10_",270
-"^CP_Tantalum_Case-A_EIA-3216-18",180
+"^CP_EIA-3216-18_",180
 "^CP_Elec_8x10.5",180
 "^CP_Elec_6.3x7.7",180
 "^CP_Elec_8x6.7",180


### PR DESCRIPTION
I cannot find the original footprint name anywhere in my libraries. It seems like it is a legacy Kicad v4 footprint? [reference](https://github.com/KiCad/Capacitors_Tantalum_SMD.pretty/blob/master/CP_Tantalum_Case-A_EIA-3216-18_Hand.kicad_mod)

Anyway, some screenshots with the new changes applied:
![image](https://user-images.githubusercontent.com/7679808/83266960-d73cc480-a1c3-11ea-86c6-2c6f34734f5e.png)
![image](https://user-images.githubusercontent.com/7679808/83266589-54b40500-a1c3-11ea-9e92-b2f7ba1bdfe8.png)
![image](https://user-images.githubusercontent.com/7679808/83266710-7dd49580-a1c3-11ea-9813-6cff4d68d9d2.png)
