### PR TITLE
Added SMD resistor array footprints to be rotated by 90 degress

### DIFF
--- a/jlc_kicad_tools/cpl_rotations_db.csv
+++ b/jlc_kicad_tools/cpl_rotations_db.csv
@@ -1,4 +1,6 @@
 "Footprint pattern","Correction"
+"^R_Array_Convex_",90
+"^R_Array_Concave_",90
 "^SOT-223",180
 "^SOT-23",180
 "^SOT-353",180


### PR DESCRIPTION
Note: in my specific case this bom item got rotated wrong:
"100K","RN1","R_Array_Convex_4x0603","C173315"

Assuming that the EasyEda footprint orientations correspond
to JLCPCB part orientations, I have checked that all the existing
resistor networks in the JLCPCB library need 90 degree rotation.