### PR TITLE
Add USB_C_Receptacle_HRO_TYPE-C-31-M-12 rotation

### DIFF
--- a/jlc_kicad_tools/cpl_rotations_db.csv
+++ b/jlc_kicad_tools/cpl_rotations_db.csv
@@ -28,3 +28,4 @@
 "^PowerPAK_SO-8_Single",270
 "^HTSSOP-28-1EP_4.4x9.7mm*",270
 "^PUIAudio_SMT_0825_S_4_R*",270
+"^USB_C_Receptacle_HRO_TYPE-C-31-M-12*",180


### PR DESCRIPTION
Still doesn't align perfectly in JLCPCB's viewer somehow, but at least the rotation is correct.

Thanks!