### PR TITLE
Include LCSC part number when grouping parts.

### DIFF
--- a/jlc_kicad_tools/generate_jlc_files.py
+++ b/jlc_kicad_tools/generate_jlc_files.py
@@ -77,12 +77,6 @@ def GetOpts():
         action="store_true",
     )
     parser.add_argument(
-        "--assume-same-lcsc-partnumber",
-        help="Assume same lcsc partnumber for all components of a group",
-        action="store_true",
-        dest="assume_same_lcsc_partnumber",
-    )
-    parser.add_argument(
         "--include-all-component-groups",
         help="Include component groups without LCSC part numbers in the BOM",
         action="store_true",

--- a/jlc_kicad_tools/jlc_lib/generate_bom.py
+++ b/jlc_kicad_tools/jlc_lib/generate_bom.py
@@ -48,61 +48,26 @@ def GenerateBOM(input_filename, output_filename, opts):
     num_groups_found = 0
     for group in grouped:
         refs = []
-        lcsc_part_numbers = set()
-        lcsc_part_numbers_none_found = False
+        lcsc_part_number = None
         footprints = set()
 
         for component in group:
             refs.append(component.getRef())
             c = component
-            lcsc_part_number = None
-
-            # Get the field name for the LCSC part number.
-            for field_name in c.getFieldNames():
-                field_value = c.getField(field_name).strip()
-
-                if LCSC_PART_NUMBER_MATCHER.match(field_value):
-                    lcsc_part_number = field_value
-
-            if lcsc_part_number:
-                lcsc_part_numbers.add(lcsc_part_number)
-            else:
-                lcsc_part_numbers_none_found = True
+            # All components in a group should have the same part number
+            lcsc_part_number = c.getLcscPartNumber()
 
             if c.getFootprint() != "":
                 footprints.add(c.getFootprint())
 
-        # Check part numbers for uniqueness
-        if len(lcsc_part_numbers) == 0 and not opts.include_all_groups:
+        if lcsc_part_number is None:
             if opts.warn_no_partnumber:
                 _LOGGER.logger.warning(
                     "No LCSC part number found for components {}".format(",".join(refs))
                 )
-            continue
-        elif len(lcsc_part_numbers) > 1:
-            _LOGGER.logger.error(
-                "Components {components} from same group have different LCSC part numbers: \
-                {partnumbers}".format(
-                    components=", ".join(refs), partnumbers=", ".join(lcsc_part_numbers)
-                )
-            )
-            return False
-
-        if lcsc_part_numbers:
-            lcsc_part_number = list(lcsc_part_numbers)[0]
-        else:
+            if not opts.include_all_groups:
+                continue
             lcsc_part_number = "no_part_number"
-
-        if (not opts.assume_same_lcsc_partnumber) and (
-            lcsc_part_numbers_none_found and not opts.include_all_groups
-        ):
-            _LOGGER.logger.error(
-                "Components {components} from same group do not all have LCSC part number \
-                {partnumber} set. Use --assume-same-lcsc-partnumber to ignore.".format(
-                    components=", ".join(refs), partnumber=lcsc_part_number
-                )
-            )
-            return False
 
         # Check footprints for uniqueness
         if len(footprints) == 0:


### PR DESCRIPTION
I'm working on a design which uses multiple LED colors, with the same
footprint. Without this change, I get the error message:

[ERROR] Components D4, D3, D2 from same group have different LCSC part numbers:                 C2286, C72043