### PR TITLE
Fixed rotation of components on the bottom of the board

### DIFF
--- a/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
+++ b/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
@@ -109,7 +109,7 @@ def FixRotations(input_filename, output_filename, db):
                             )
                         )
                         if row[side_index].strip() == "bottom":
-                            rotation = (rotation - correction) % 360
+                            rotation = (rotation + correction + 180) % 360
                         else:
                             rotation = (rotation + correction) % 360
                         row[rotation_index] = "{0:.6f}".format(rotation)


### PR DESCRIPTION
If a component has a rotation offset of 0° or 180°, it will be 180° off if it is on the bottom of the board. 
This fix does not affect components with 90° or 270° offsets, which I assume is what this script was tested with.