### PR TITLE
Correctly fix bottom layer rotations for all component adjustments.

### DIFF
--- a/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
+++ b/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
@@ -101,18 +101,23 @@ def FixRotations(input_filename, output_filename, db):
                 if flip_x:
                     row[posx_index] = "{0:.6f}".format(-float(row[posx_index]))
 
+                no_match = True
                 for pattern, correction in db.items():
                     if pattern.match(row[package_index]):
+                        no_match = False
                         _LOGGER.logger.info(
                             "Footprint {} matched {}. Applying {} deg correction".format(
                                 row[package_index], pattern.pattern, correction
                             )
                         )
                         if row[side_index].strip() == "bottom":
-                            rotation = (rotation + correction + 180) % 360
+                            rotation = (rotation - correction + 180) % 360
                         else:
                             rotation = (rotation + correction) % 360
                         row[rotation_index] = "{0:.6f}".format(rotation)
                         break
+                if no_match and row[side_index].strip() == "bottom":
+                    rotation = (rotation + 180) % 360
+                    row[rotation_index] = "{0:.6f}".format(rotation)
             writer.writerow(row)
     return True


### PR DESCRIPTION
It looks like JLCPCB has changed how they interpret **bottom layer** rotations.
A project I had ordered before (with unmodified bom and cpl files) had all its components rotated by 180 degrees.

Looks like Pull request https://github.com/matthewlai/JLCKicadTools/pull/78 has tried to address it
but it was incomplete, the current master is not rotating all components correctly yet.
This PR corrects bottom layer rotation for all component types.

Some examples:
1) This is correct on both current master, and on this PR too: (this is a 180-degree corrected component)
![image](https://user-images.githubusercontent.com/544648/153784857-feaa8f4d-d9bf-406d-8fa9-3838a491d0f4.png)
2) The following is incorrect on master: (this is a 270-degree corrected component)
![image](https://user-images.githubusercontent.com/544648/153784897-9b3d967a-883e-4050-9a0a-1abfb0cb0bae.png)
But it's correct with this PR:
![image](https://user-images.githubusercontent.com/544648/153784910-880037fb-f380-4ce9-9e76-bba79dadcb23.png)