### PR TITLE
Bugfix for recent regression and update bottom layer rotation calculation

### DIFF
--- a/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
+++ b/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
@@ -142,7 +142,8 @@ def FixRotations(input_filename, output_filename, db):
                     #  (note: when the change was noticed does not necessarily correspond with when JLCPCB changed behaviour)
                     # Around 2020 August: rotation = rotation # no change
                     # Around 2022 February: rotation = (rotation + 180) % 360
-                    rotation = (rotation + 180) % 360
+                    # Around 2022 July: rotation = (-rotation + 180) % 360
+                    rotation = (-rotation + 180) % 360
 
                 row[rotation_index] = "{0:.6f}".format(rotation)
             writer.writerow(row)

--- a/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
+++ b/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
@@ -123,9 +123,9 @@ def FixRotations(input_filename, output_filename, db):
 
                 if last_correction is not None:
                     if row[side_index].strip() == "bottom":
-                        rotation = (rotation - correction + 180) % 360
+                        rotation = (rotation - last_correction + 180) % 360
                     else:
-                        rotation = (rotation + correction) % 360
+                        rotation = (rotation + last_correction) % 360
                     row[rotation_index] = "{0:.6f}".format(rotation)
 
                 if last_correction is None and row[side_index].strip() == "bottom":


### PR DESCRIPTION
This PR contains 3 commits:

- Bugfix for recent regression of using value "correction" which is out of scope.
    
    This was introduced in commit 5ecf6c9b138d0d192f615a7cce9f6a3f0cf5b490
    "correction" will simply contain the last correction that was in the database.
    Instead, last_correction is the correct value for the last correction with a
    matching pattern.
 

- Refactor how bottom layer rotations are calculated, for better clarity. (no functional change)
    
    This splits up bottom layer calculations in two halves:
    1) The Kicad-specific half, of corrections needing to be applied with a negative sign on the bottom layer
    2) The JLCPCB-specific half, of how to further tweak the rotation numbers on the bottom for it to be correctly handled by JLCPCB.

- Update how bottom layer rotations are calculated, to match current JLCPCB behaviour (as first noticed on 2022 Jul 31).
