### PR TITLE
rotations: add Quectel L80-R

### DIFF
--- a/jlc_kicad_tools/cpl_rotations_db.csv
+++ b/jlc_kicad_tools/cpl_rotations_db.csv
@@ -54,3 +54,4 @@
 "^JST_GH_SM",180
 "^JST_PH_S",180
 "^Diodes_PowerDI3333-8",270
+"^Quectel_L80-R",270


### PR DESCRIPTION
The Quectel L80-R needs to be rotated by -90 degrees.

Signed-off-by: David Bauer <mail@david-bauer.net>