### PR TITLE
Update BOM Header and WS2812B Rotation

### DIFF
--- a/jlc_kicad_tools/cpl_rotations_db.csv
+++ b/jlc_kicad_tools/cpl_rotations_db.csv
@@ -48,7 +48,6 @@
 "^Relay_DPDT_Omron_G6K-2F-Y",270
 "^RP2040-QFN-56",270
 "^TO-277",90
-"^LED_WS2812B",180
 "^SW_SPST_B3",90
 "^Transformer_Ethernet_Pulse_HX0068ANL",270
 "^JST_GH_SM",180

--- a/jlc_kicad_tools/jlc_lib/generate_bom.py
+++ b/jlc_kicad_tools/jlc_lib/generate_bom.py
@@ -41,7 +41,7 @@ def GenerateBOM(input_filename, output_filename, opts):
         f, lineterminator="\n", delimiter=",", quotechar='"', quoting=csv.QUOTE_ALL
     )
 
-    out.writerow(["Comment", "Designator", "Footprint", "LCSC Part #"])
+    out.writerow(["Comment", "Designator", "Footprint", "LCSC Part Number"])
 
     grouped = net.groupComponents()
 


### PR DESCRIPTION
When preparing a PCB order tonight, I needed two changes to the existing script.  First, the header for the LCSC Part # field is now expected to be "LCSC Part Number" per the instructions page[0]. Second, I've found that removing the rotation modifier yields the correct orientation for the WS2812B LEDs that JLCPCB currently stocks so I removed it from the database.

[0] - https://support.jlcpcb.com/article/84-how-to-generate-the-bom-and-centroid-file-from-kicad