### PR TITLE
fix bom file encode error

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ $ jlc-kicad-tools
 ### FAQ
 1. Why are some components in the generated files but don't show up on JLCPCB preview?
 
-    * Make sure there are no non-ASCII characters in any of the fields. See: https://github.com/matthewlai/JLCKicadTools/issues/45
+    * ~~Make sure there are no non-ASCII characters in any of the fields. See:~~ https://github.com/matthewlai/JLCKicadTools/issues/45
+
+    * Please update to lastest version.

--- a/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
+++ b/jlc_kicad_tools/jlc_lib/cpl_fix_rotations.py
@@ -57,7 +57,7 @@ def ReadDB(filename):
 
 
 def FixRotations(input_filename, output_filename, db):
-    with open(input_filename) as csvfile:
+    with open(input_filename, encoding='utf-8') as csvfile:
         reader = csv.reader(csvfile, delimiter=",")
         writer = csv.writer(open(output_filename, "w", newline=""), delimiter=",")
         package_index = None


### PR DESCRIPTION
In Windows 10 Simplified Chinese version, reading BOM files containing non-English characters (such as Chinese) will result in an error：
```shell
  File "e:\ProgramData\Miniconda3\Lib\site-packages\jlc_kicad_tools\jlc_lib\cpl_fix_rotations.py", line 69, in FixRotations
    for row in reader:
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa8 in position 51: illegal multibyte sequence
```